### PR TITLE
Pass data using 'json' so it gets encoded and correctly mimetype-d.

### DIFF
--- a/paystackapi/base.py
+++ b/paystackapi/base.py
@@ -55,7 +55,7 @@ class PayStackRequests(object):
         """
         data = kwargs.get('data')
         response = method(self.API_BASE_URL + resource_uri,
-                          data=data, headers=self.headers)
+                          json=data, headers=self.headers)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
Hi...thanks for releasing this.

While using the latest version (1.2.4) in a project with Python 3.6, I noticed that trying to create plans kept returning a `400: Bad Request`. Specifically:

    from paystackapi.paystack import Plan
    params = {'name': 'Some Plan', ...}
    response = Plan.create(**params)

Enabling logging for `requests`, I discovered that the `Content-type` was being set to `application/x-www-urlencoded`, and the data posted as key/value pairs, which Paystack doesn't support. This appears to be the default behaviour for `requests`.

Changing the `data` parameter in `paystackapi.base.PaystackRequests._request` to `json` works (it correctly sets the `Content-type` to `application/json` and JSON-encodes the payload), and has been supported since [version 2.4.2](https://github.com/kennethreitz/requests/pull/2258). I'm a bit confused though - is this a Python 3.6-only issue? Or are you manually JSON-encoding your data somehow?