### PR TITLE
Pass data using 'json' so it gets encoded and correctly mimetype-d.

### DIFF
--- a/paystackapi/base.py
+++ b/paystackapi/base.py
@@ -55,7 +55,7 @@ class PayStackRequests(object):
         """
         data = kwargs.get('data')
         response = method(self.API_BASE_URL + resource_uri,
-                          data=data, headers=self.headers)
+                          json=data, headers=self.headers)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
Pass data to `requests` using the `json` parameter (available since version 2.4.2), so it is automatically JSON-encoded, and sent with the correct `Content-type`.