### PR TITLE
Transaction initialize fix

### DIFF
--- a/paystackapi/tests/test_transaction.py
+++ b/paystackapi/tests/test_transaction.py
@@ -13,7 +13,7 @@ class TestTransaction(unittest.TestCase):
     @httpretty.activate
     def test_initialize(self):
         httpretty.register_uri(
-            httpretty.GET,
+            httpretty.POST,
             "https://api.paystack.co/transaction/initialize",
             content_type='text/json',
             body='{"status": true, "contributors": true}',

--- a/paystackapi/transaction.py
+++ b/paystackapi/transaction.py
@@ -21,7 +21,7 @@ class Transaction(PayStackBase):
             Json data from paystack API.
         """
 
-        return cls().requests.get('transaction/initialize', data=kwargs)
+        return cls().requests.post('transaction/initialize', data=kwargs)
 
     @classmethod
     def charge(cls, **kwargs):


### PR DESCRIPTION
Hi again,

I ran into the issue reported in #26. It appears to be caused by `paystackapi.transaction.Transaction.initialize` sending a `GET` rather than a `POST`. This pull request fixes that.