### PR TITLE
feat: added subscription endpoint --> Generate a link for updating th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ target/
 .vscode/
 
 notes.txt
+sandbox

--- a/docs/subscription.md
+++ b/docs/subscription.md
@@ -88,3 +88,19 @@ response = Subscription.enable(code="SUB_vsyqdmlzble3uii",
 *Returns*
 
 JSON data from paystack API.
+
+
+##### `Subscription.generate_update_subscription_link(subscription_code)` - Generate a link for updating the card on a subscription
+```python
+from paystackapi.subscription import Subscription
+response = Subscription.generate_update_subscription_link(
+    subscription_code='SUB_vsyqdmlzble3uii'
+)
+```
+
+*Arguments*
+- `subscription_code`: subscription code
+
+*Returns*
+
+JSON data from paystack API.

--- a/paystackapi/subscription.py
+++ b/paystackapi/subscription.py
@@ -76,3 +76,16 @@ class Subscription(PayStackBase):
             Json data from paystack API.
         """
         return cls().requests.get(f"subscription/{subscription_id}")
+
+    @classmethod
+    def generate_update_subscription_link(cls, subscription_code):
+        """
+        Generate a link for updating the card on a subscription
+        
+        Args:
+            subscription_code: subscription code.
+        
+        Returns:
+            Json data from paystack API.
+        """
+        return cls().requests.get(f"subscription/{subscription_code}/manage/link")

--- a/paystackapi/tests/test_subscription.py
+++ b/paystackapi/tests/test_subscription.py
@@ -93,5 +93,5 @@ class TestSubscription(BaseTestCase):
             status=200,
         )
 
-        response = Subscription.fetch(subscription_code='SUB_vsyqdmlzble3uii')
+        response = Subscription.generate_update_subscription_link(subscription_code='SUB_vsyqdmlzble3uii')
         self.assertEqual(response['status'], True)

--- a/paystackapi/tests/test_subscription.py
+++ b/paystackapi/tests/test_subscription.py
@@ -82,3 +82,16 @@ class TestSubscription(BaseTestCase):
 
         response = Subscription.enable(code="SUB_vsyqdmlzble3uii", token="d7gofp6yppn3qz7")
         self.assertEqual(response['status'], True)
+
+    @httpretty.activate
+    def test_generate_update_subscription_link(self):
+        """Function defined to test generation of a link for updating the card on a subscription"""
+        httpretty.register_uri(
+            httpretty.GET,
+            self.endpoint_url("/subscription/SUB_vsyqdmlzble3uii/manage/link"),
+            content_type='text/json',
+            status=200,
+        )
+
+        response = Subscription.fetch(subscription_code='SUB_vsyqdmlzble3uii')
+        self.assertEqual(response['status'], True)


### PR DESCRIPTION
---
name: Subscription -- Generate a link for updating the card on a subscription
about: Suggest an idea for this project
title: 'Feature: Resource to Generate a link for updating the card on a subscription'
labels: new feature ✨
assignees: ''

---

**🙁 Is your feature request related to a problem? Please describe.**
- Paystack API currently have an endpoint to auto generate a Link to be used to update subscription
- You can update the subscription card details or choose to cancel subscription from there
- Resouce implementation under "Generate a link for updating the card on a subscription"
- This endpoint implementation is not captured in this paystack-python as of version 2.1.2 url="https://api.paystack.co/subscription/{code}/manage/link"


**🤩 Describe the solution you'd like**
- Implement the resource that takes in the "subscription_code" as a path parameter
- Response returns a Link to be used for updating subscription

**😑 Describe alternatives you've considered**
- Manually make requests to the source endpoint at url=`"https://api.paystack.co/subscription/{code}/manage/link"`

**Acceptance Criteria ✅** 
The following items should be accomplished to consider this feature complete

- [ ] Make a PR to solve this issue. 
- [ ] Document the problem, process and resolution
- [ ] Write test cases for the problem

**Additional context (screenshots, explainer videos etc) **
None