### PR TITLE
Feat:Subscription --> Email a customer a link for updating the card on their subscription 

### DIFF
--- a/docs/subscription.md
+++ b/docs/subscription.md
@@ -104,3 +104,20 @@ response = Subscription.generate_update_subscription_link(
 *Returns*
 
 JSON data from paystack API.
+
+
+##### `Subscription.send_update_subscription_link(subscription_code)` - Email a customer a link for updating the card on their subscription
+
+```python
+from paystackapi.subscription import Subscription
+response = Subscription.send_update_subscription_link(
+    subscription_code='SUB_vsyqdmlzble3uii'
+)
+```
+
+*Arguments*
+- `subscription_code`: subscription code
+
+*Returns*
+
+JSON data from paystack API.

--- a/paystackapi/subscription.py
+++ b/paystackapi/subscription.py
@@ -89,3 +89,16 @@ class Subscription(PayStackBase):
             Json data from paystack API.
         """
         return cls().requests.get(f"subscription/{subscription_code}/manage/link")
+    
+    @classmethod
+    def send_update_subscription_link(cls, subscription_code):
+        """
+        Email a customer a link for updating the card on their subscription
+        
+        Args:
+            subscription_code: subscription code.
+        
+        Returns:
+            Json data from paystack API.
+        """
+        return cls().requests.post(f"subscription/{subscription_code}/manage/email")

--- a/paystackapi/tests/test_subscription.py
+++ b/paystackapi/tests/test_subscription.py
@@ -93,5 +93,18 @@ class TestSubscription(BaseTestCase):
             status=200,
         )
 
-        response = Subscription.fetch(subscription_code='SUB_vsyqdmlzble3uii')
+        response = Subscription.generate_update_subscription_link(subscription_code='SUB_vsyqdmlzble3uii')
+        self.assertEqual(response['status'], True)
+        
+    @httpretty.activate
+    def test_send_update_subscription_link(self):
+        """Function defined to test emailing a customer a link for updating the card on their subscription"""
+        httpretty.register_uri(
+            httpretty.POST,
+            self.endpoint_url("/subscription/SUB_vsyqdmlzble3uii/manage/email"),
+            content_type='text/json',
+            status=200,
+        )
+
+        response = Subscription.send_update_subscription_link(subscription_code='SUB_vsyqdmlzble3uii')
         self.assertEqual(response['status'], True)


### PR DESCRIPTION
---
name: Subscription -- Generate a link for updating the card on a subscription
about: Suggest an idea for this project
title: 'Feature: Resource to Generate a link for updating the card on a subscription'
labels: new feature ✨
assignees: ''

---

**🙁 Is your feature request related to a problem? Please describe.**
- Resource implementation of emailing a user a Link to to update their subscription details "Generate a link for updating the card on a subscription"
- This endpoint implementation is not captured in this paystack-python as of version 2.1.2 


**🤩 Describe the solution you'd like**
- Implement the resource that takes in the "subscription_code" as a path parameter
- Response returns True if the email link is successfully sent to the customer/user

**😑 Describe alternatives you've considered**
- Manually make requests to the source endpoint at url=`"https://api.paystack.co/subscription/{code}/manage/email"`

**Acceptance Criteria ✅** 
The following items should be accomplished to consider this feature complete

- [x] Make a PR to solve this issue. 
- [x] Document the problem, process and resolution
- [x] Write test cases for the problem

**Additional context (screenshots, explainer videos etc) **
None